### PR TITLE
Conductivity interface update

### DIFF
--- a/Microphysics/EOS/eos_type.f90
+++ b/Microphysics/EOS/eos_type.f90
@@ -145,6 +145,8 @@ module eos_type_module
     real(dp_t) :: dedA
     real(dp_t) :: dedZ
 
+    real(dp_t) :: conductivity
+
   end type eos_t
 
 contains

--- a/Microphysics/conductivity/conductivity.f90
+++ b/Microphysics/conductivity/conductivity.f90
@@ -26,7 +26,7 @@ contains
 
   ! a generic wrapper that calls the EOS and then the conductivity
 
-  subroutine conducteos(input, state, cond)
+  subroutine conducteos(input, state)
 
     use actual_conductivity_module
     use eos_type_module, only : eos_t
@@ -36,14 +36,11 @@ contains
 
     integer         , intent(in   ) :: input
     type (eos_t)    , intent(inout) :: state
-    real (kind=dp_t), intent(inout) :: cond
 
     ! call the EOS, passing through the arguments we called conducteos with
     call eos(input, state)
 
     call actual_conductivity(state)
-
-    cond = state % conductivity
 
   end subroutine conducteos
 

--- a/Microphysics/conductivity/conductivity.f90
+++ b/Microphysics/conductivity/conductivity.f90
@@ -41,7 +41,9 @@ contains
     ! call the EOS, passing through the arguments we called conducteos with
     call eos(input, state)
 
-    call actual_conductivity(state, cond)
+    call actual_conductivity(state)
+
+    cond = state % conductivity
 
   end subroutine conducteos
 

--- a/Source/make_explicit_thermal.f90
+++ b/Source/make_explicit_thermal.f90
@@ -307,7 +307,6 @@ contains
     ! local
     integer :: i,comp    
     type (eos_t) :: eos_state
-    real (kind=dp_t) :: conductivity
 
 
     do i=lo(1)-1,hi(1)+1
@@ -328,17 +327,17 @@ contains
           eos_state%xn(:) = s(i,spec_comp:spec_comp+nspec-1)/eos_state%rho
           
           ! dens, temp, and xmass are inputs
-          call conducteos(eos_input_rt, eos_state, conductivity)
+          call conducteos(eos_input_rt, eos_state)
           
-          Tcoeff(i) = -conductivity
-          hcoeff(i) = -conductivity/eos_state%cp
-          pcoeff(i) = (conductivity/eos_state%cp)* &
+          Tcoeff(i) = -eos_state % conductivity
+          hcoeff(i) = -eos_state % conductivity/eos_state%cp
+          pcoeff(i) = (eos_state % conductivity/eos_state%cp)* &
                ((1.0d0/eos_state%rho)* &
                (1.0d0-eos_state%p/(eos_state%rho*eos_state%dpdr))+ &
                eos_state%dedr/eos_state%dpdr)
        
           do comp=1,nspec
-             Xkcoeff(i,comp) = (conductivity/eos_state%cp)*eos_state%dhdX(comp)
+             Xkcoeff(i,comp) = (eos_state % conductivity/eos_state%cp)*eos_state%dhdX(comp)
           enddo
 
        endif
@@ -374,7 +373,6 @@ contains
     ! local
     integer :: i,j,comp    
     type (eos_t) :: eos_state
-    real (kind=dp_t) :: conductivity
     
     do j=lo(2)-1,hi(2)+1
        do i=lo(1)-1,hi(1)+1
@@ -395,17 +393,17 @@ contains
              eos_state%xn(:) = s(i,j,spec_comp:spec_comp+nspec-1)/eos_state%rho
              
              ! dens, temp, and xmass are inputs
-             call conducteos(eos_input_rt, eos_state, conductivity)
+             call conducteos(eos_input_rt, eos_state)
              
-             Tcoeff(i,j) = -conductivity
-             hcoeff(i,j) = -conductivity/eos_state%cp
-             pcoeff(i,j) = (conductivity/eos_state%cp)* &
+             Tcoeff(i,j) = -eos_state % conductivity
+             hcoeff(i,j) = -eos_state % conductivity/eos_state%cp
+             pcoeff(i,j) = (eos_state % conductivity/eos_state%cp)* &
                   ((1.0d0/eos_state%rho)* &
                   (1.0d0-eos_state%p/(eos_state%rho*eos_state%dpdr))+ &
                   eos_state%dedr/eos_state%dpdr)
              
              do comp=1,nspec
-                Xkcoeff(i,j,comp) = (conductivity/eos_state%cp)*eos_state%dhdX(comp)
+                Xkcoeff(i,j,comp) = (eos_state % conductivity/eos_state%cp)*eos_state%dhdX(comp)
              enddo
 
           endif
@@ -442,9 +440,8 @@ contains
     ! local
     integer :: i,j,k,comp
     type (eos_t) :: eos_state
-    real (kind=dp_t) :: conductivity
     
-    !$OMP PARALLEL DO PRIVATE(i,j,k,comp,eos_state,conductivity)
+    !$OMP PARALLEL DO PRIVATE(i,j,k,comp,eos_state)
     do k=lo(3)-1,hi(3)+1
        do j=lo(2)-1,hi(2)+1
           do i=lo(1)-1,hi(1)+1
@@ -466,17 +463,17 @@ contains
                 eos_state%xn(:) = s(i,j,k,spec_comp:spec_comp+nspec-1)/eos_state%rho
              
                 ! dens, temp, and xmass are inputs
-                call conducteos(eos_input_rt, eos_state, conductivity)
+                call conducteos(eos_input_rt, eos_state)
                 
-                Tcoeff(i,j,k) = -conductivity
-                hcoeff(i,j,k) = -conductivity/eos_state%cp
-                pcoeff(i,j,k) = (conductivity/eos_state%cp)* &
+                Tcoeff(i,j,k) = -eos_state % conductivity
+                hcoeff(i,j,k) = -eos_state % conductivity/eos_state%cp
+                pcoeff(i,j,k) = (eos_state % conductivity/eos_state%cp)* &
                      ((1.0d0/eos_state%rho)* &
                      (1.0d0-eos_state%p/(eos_state%rho*eos_state%dpdr))+ &
                      eos_state%dedr/eos_state%dpdr)
                 
                 do comp=1,nspec
-                   Xkcoeff(i,j,k,comp) = (conductivity/eos_state%cp)*eos_state%dhdX(comp)
+                   Xkcoeff(i,j,k,comp) = (eos_state % conductivity/eos_state%cp)*eos_state%dhdX(comp)
                 enddo
 
              endif

--- a/Source/make_plot_variables.f90
+++ b/Source/make_plot_variables.f90
@@ -482,7 +482,6 @@ contains
     integer :: i
 
     type (eos_t) :: eos_state
-    real (kind=dp_t) :: conductivity
 
     do i = lo(1), hi(1)
 
@@ -490,9 +489,9 @@ contains
        eos_state%T     = state(i,temp_comp)
        eos_state%xn(:) = state(i,spec_comp:spec_comp+nspec-1) / eos_state%rho
 
-       call conducteos(eos_input_rt, eos_state, conductivity)
+       call conducteos(eos_input_rt, eos_state)
 
-       cond(i) = conductivity
+       cond(i) = eos_state % conductivity
 
     enddo
 
@@ -514,7 +513,6 @@ contains
     integer :: i, j
 
     type (eos_t) :: eos_state
-    real (kind=dp_t) :: conductivity
 
     do j = lo(2), hi(2)
        do i = lo(1), hi(1)
@@ -523,9 +521,9 @@ contains
           eos_state%T     = state(i,j,temp_comp)
           eos_state%xn(:) = state(i,j,spec_comp:spec_comp+nspec-1) / eos_state%rho
 
-          call conducteos(eos_input_rt, eos_state, conductivity)
+          call conducteos(eos_input_rt, eos_state)
 
-          cond(i,j) = conductivity
+          cond(i,j) = eos_state % conductivity
 
        enddo
     enddo
@@ -548,9 +546,8 @@ contains
     integer :: i, j, k
 
     type (eos_t) :: eos_state
-    real (kind=dp_t) :: conductivity
 
-    !$OMP PARALLEL DO PRIVATE(i,j,k,eos_state,conductivity)
+    !$OMP PARALLEL DO PRIVATE(i,j,k,eos_state)
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
           do i = lo(1), hi(1)
@@ -560,9 +557,9 @@ contains
              eos_state%xn(:) = state(i,j,k,spec_comp:spec_comp+nspec-1) / &
                            eos_state%rho
 
-             call conducteos(eos_input_rt, eos_state, conductivity)
+             call conducteos(eos_input_rt, eos_state)
 
-             cond(i,j,k) = conductivity
+             cond(i,j,k) = eos_state % conductivity
 
           enddo
        enddo


### PR DESCRIPTION
This update is for the conductivity-update branch in Microphysics, which puts conductivity into the `eos_type` and unifies the conductivity interface to mimic the eos interface.

Relies on https://github.com/starkiller-astro/Microphysics/pull/164